### PR TITLE
evidence-connector-oracledb

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A collection of awesome resources for building with Evidence
 - [Google Sheets](https://github.com/evidence-dev/datasources/tree/main/gsheets) - Load a private or public google sheet into Evidence
 - [Microsoft SQL Server - Azure AD Auth](https://github.com/timothyhoward/evidence-connector-mssql) - Azure AD Authentication for MS SQL Server source
 - [NPM Stats](https://github.com/archiewood/npm-stats) - Load the download stats for any public npm package into Evidence from an API
+- [OracleDB SQL driver for Evidence projects](https://github.com/rinie/evidence-connector-oracledb) - First shot at OracleDB Datasource
 
 ## Component Plugins
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A collection of awesome resources for building with Evidence
 - [Google Sheets](https://github.com/evidence-dev/datasources/tree/main/gsheets) - Load a private or public google sheet into Evidence
 - [Microsoft SQL Server - Azure AD Auth](https://github.com/timothyhoward/evidence-connector-mssql) - Azure AD Authentication for MS SQL Server source
 - [NPM Stats](https://github.com/archiewood/npm-stats) - Load the download stats for any public npm package into Evidence from an API
-- [OracleDB SQL driver for Evidence projects](https://github.com/rinie/evidence-connector-oracledb) - First shot at OracleDB Datasource
+- [evidence-connector-oracledb](https://github.com/rinie/evidence-connector-oracledb) - First shot at OracleDB Datasource or NPM evidence-connector-oracledb
 
 ## Component Plugins
 


### PR DESCRIPTION
First shot at evidence-connector-oracledb to connect to Oracle Databases using node-oracledb either thin mode (no oracle driver installations needed) or thick mode.